### PR TITLE
Improve test coverage for unexpected HTML entity escaping in libxml 2.7.5 and later

### DIFF
--- a/test/unit/test_xss_foliate.rb
+++ b/test/unit/test_xss_foliate.rb
@@ -186,6 +186,10 @@ class TestXssFoliate < Test::Unit::TestCase
     end
 
     context "these tests should pass for libxml 2.7.5 and later" do
+      setup do
+        Post.xss_foliate
+      end
+
       should "not scrub double quotes into html entities" do
         answer = new_post(:plain_text => "\"something\"")
         answer.valid?


### PR DESCRIPTION
Set up xss_foliate in the test context "these tests should pass for libxml 2.7.5 and later". This doesn't fix the tests, but it does make them properly fail.

See my comment on loofah at https://github.com/flavorjones/loofah/issues/20#issuecomment-1751538 for more details…
